### PR TITLE
Add 'quiet' Parameter to Improve Benchmark Output Handling

### DIFF
--- a/neurobench/benchmarks/benchmark.py
+++ b/neurobench/benchmarks/benchmark.py
@@ -23,7 +23,7 @@ class Benchmark():
         self.static_metrics = {m: getattr(static_metrics, m) for m in metric_list[0]}
         self.data_metrics = {m: getattr(data_metrics, m) for m in metric_list[1]}
 
-    def run(self):
+    def run(self, quiet=False):
         """ Runs batched evaluation of the benchmark.
 
         Currently, data metrics are accumulated via mean over the entire
@@ -52,7 +52,7 @@ class Benchmark():
         dataset_len = len(self.dataloader.dataset)
         
         batch_num = 0
-        for data in tqdm(self.dataloader, total=len(self.dataloader)):
+        for data in tqdm(self.dataloader, total=len(self.dataloader), disable=quiet):
             batch_size = data[0].size(0)
             
             # convert data to tuple

--- a/neurobench/benchmarks/benchmark.py
+++ b/neurobench/benchmarks/benchmark.py
@@ -32,6 +32,9 @@ class Benchmark():
         Currently, data metrics are accumulated via mean over the entire
         test set, and thus must return a float or int.
 
+        Args:
+            quiet (bool, default=False): If True, output is suppressed.
+
         Returns:
             results: A dictionary of results.
         """

--- a/neurobench/benchmarks/benchmark.py
+++ b/neurobench/benchmarks/benchmark.py
@@ -1,4 +1,7 @@
+import sys
+
 from tqdm import tqdm
+from contextlib import redirect_stdout
 
 from . import static_metrics, data_metrics
 
@@ -32,69 +35,70 @@ class Benchmark():
         Returns:
             results: A dictionary of results.
         """
-        print("Running benchmark")
+        with redirect_stdout(None if quiet else sys.stdout):
+            print("Running benchmark")
         
-        # add hooks to the model
-        data_metrics.detect_activations_connections(self.model)
+            # add hooks to the model
+            data_metrics.detect_activations_connections(self.model)
 
-        # Static metrics
-        results = {}
-        for m in self.static_metrics.keys():
-            results[m] = self.static_metrics[m](self.model)
+            # Static metrics
+            results = {}
+            for m in self.static_metrics.keys():
+                results[m] = self.static_metrics[m](self.model)
 
-        # Init/re-init stateful data metrics
-        for m in self.data_metrics.keys():
-            if isinstance(self.data_metrics[m],type) and issubclass(self.data_metrics[m], data_metrics.AccumulatedMetric):
-                self.data_metrics[m] = self.data_metrics[m]()
-            elif isinstance(self.data_metrics[m], data_metrics.AccumulatedMetric):
-                self.data_metrics[m] = self.data_metrics[m]()
-
-        dataset_len = len(self.dataloader.dataset)
-        
-        batch_num = 0
-        for data in tqdm(self.dataloader, total=len(self.dataloader), disable=quiet):
-            batch_size = data[0].size(0)
-            
-            # convert data to tuple
-            if type(data) is not tuple:
-                data = tuple(data)
-
-            # Preprocessing data
-            for alg in self.preprocessors:
-                data = alg(data)
-
-            # Run model on test data
-            preds = self.model(data[0])
-
-            for alg in self.postprocessors: 
-                preds = alg(preds)
-
-            # Data metrics
-            batch_results = {}
+            # Init/re-init stateful data metrics
             for m in self.data_metrics.keys():
-                batch_results[m] = self.data_metrics[m](self.model, preds, data)
+                if isinstance(self.data_metrics[m],type) and issubclass(self.data_metrics[m], data_metrics.AccumulatedMetric):
+                    self.data_metrics[m] = self.data_metrics[m]()
+                elif isinstance(self.data_metrics[m], data_metrics.AccumulatedMetric):
+                    self.data_metrics[m] = self.data_metrics[m]()
 
-            for m, v in batch_results.items():
-                # AccumulatedMetrics are computed after all batches complete
-                if isinstance(self.data_metrics[m], data_metrics.AccumulatedMetric):
-                    continue
-                # otherwise accumulate via mean
-                else:
-                    assert isinstance(v, float) or isinstance(v, int), "Data metric must return float or int to be accumulated"
-                    if m not in results:
-                        results[m] = v * batch_size / dataset_len
+            dataset_len = len(self.dataloader.dataset)
+
+            batch_num = 0
+            for data in tqdm(self.dataloader, total=len(self.dataloader), disable=quiet):
+                batch_size = data[0].size(0)
+
+                # convert data to tuple
+                if type(data) is not tuple:
+                    data = tuple(data)
+
+                # Preprocessing data
+                for alg in self.preprocessors:
+                    data = alg(data)
+
+                # Run model on test data
+                preds = self.model(data[0])
+
+                for alg in self.postprocessors:
+                    preds = alg(preds)
+
+                # Data metrics
+                batch_results = {}
+                for m in self.data_metrics.keys():
+                    batch_results[m] = self.data_metrics[m](self.model, preds, data)
+
+                for m, v in batch_results.items():
+                    # AccumulatedMetrics are computed after all batches complete
+                    if isinstance(self.data_metrics[m], data_metrics.AccumulatedMetric):
+                        continue
+                    # otherwise accumulate via mean
                     else:
-                        results[m] += v * batch_size / dataset_len
-            
-            # delete hook contents
-            self.model.reset_hooks()
+                        assert isinstance(v, float) or isinstance(v, int), "Data metric must return float or int to be accumulated"
+                        if m not in results:
+                            results[m] = v * batch_size / dataset_len
+                        else:
+                            results[m] += v * batch_size / dataset_len
 
-            batch_num += 1
-                
+                # delete hook contents
+                self.model.reset_hooks()
 
-        # compute AccumulatedMetrics after all batches
-        for m in self.data_metrics.keys():
-            if isinstance(self.data_metrics[m], data_metrics.AccumulatedMetric):
-                results[m] = self.data_metrics[m].compute()
+                batch_num += 1
+
+
+            # compute AccumulatedMetrics after all batches
+            for m in self.data_metrics.keys():
+                if isinstance(self.data_metrics[m], data_metrics.AccumulatedMetric):
+                    results[m] = self.data_metrics[m].compute()
 
         return results


### PR DESCRIPTION
This pull request introduces a 'quiet' parameter to the benchmark.run() function, addressing the issue of excessive output generated during quick benchmark runs. 

Related Issue: https://github.com/NeuroBench/neurobench/issues/142#issue-1957995144