### PR TITLE
Fix Test Metrics

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -311,8 +311,10 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model_relu_0, out_relu,  (inp,0))
 
-    assert syn_ops['MACs'] == 1125
-    assert syn_ops['ACs'] == 0
+    print(syn_ops)
+
+    assert syn_ops['Effective_MACs'] == 1125
+    assert syn_ops['Effective_ACs'] == 0
 
     # test model with Identity layer as first layer
     net_relu_50 = nn.Sequential(
@@ -336,8 +338,8 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model_relu_50, out_relu_50,  (inp,0))
 
-    assert syn_ops['MACs'] == (2*625 + 400 + 500)
-    assert syn_ops['ACs'] == 0
+    assert syn_ops['Effective_MACs'] == (2*625 + 400 + 500)
+    assert syn_ops['Effective_ACs'] == 0
 
     # test conv2d layers
     net_conv = nn.Sequential(
@@ -355,8 +357,9 @@ def test_synaptic_ops():
     out = model(inp)
     syn = synaptic_operations()
     syn_ops = syn(model, out, (inp,0))
-    assert syn_ops['MACs'] == 9
-    assert syn_ops['ACs'] == 0
+
+    assert syn_ops['Effective_MACs'] == 9
+    assert syn_ops['Effective_ACs'] == 0
 
     model.reset_hooks()
     inp = torch.ones(1, 1, 12, 12) # (12-(kernelsize-1))**2 * 9 synops per kernel ops= 100*9 syn ops = 900
@@ -366,8 +369,9 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model, out, (inp,0))
 
-    assert syn_ops['MACs'] == 900
-    assert syn_ops['ACs'] == 0
+
+    assert syn_ops['Effective_MACs'] == 900
+    assert syn_ops['Effective_ACs'] == 0
 
     # test conv1d layers
     net_conv = nn.Sequential(
@@ -386,8 +390,8 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model, out, (inp,0))
 
-    assert syn_ops['MACs'] == 150
-    assert syn_ops['ACs'] == 0
+    assert syn_ops['Effective_MACs'] == 150
+    assert syn_ops['Effective_ACs'] == 0
 
     # test snn layers
     net_snn = nn.Sequential(
@@ -409,8 +413,8 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model, out,  (inp,0))
 
-    assert syn_ops['MACs'] == 0
-    assert syn_ops['ACs'] == 1000
+    assert syn_ops['Effective_MACs'] == 0
+    assert syn_ops['Effective_ACs'] == 1000
 
     # test lstm network
     net_lstm = simple_LSTM()
@@ -426,8 +430,8 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model, out, inp)
 
-    assert syn_ops['MACs'] == 615
-    assert syn_ops['ACs'] == 0
+    assert syn_ops['Effective_MACs'] == 615
+    assert syn_ops['Effective_ACs'] == 0
 
     # test RNN network
     net_RNN = simple_RNN()
@@ -443,8 +447,8 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model, out, inp)
 
-    assert syn_ops['MACs'] == 150
-    assert syn_ops['ACs'] == 0
+    assert syn_ops['Effective_MACs'] == 150
+    assert syn_ops['Effective_ACs'] == 0
 
     # test GRU network
     net_GRU = simple_GRU()
@@ -460,8 +464,8 @@ def test_synaptic_ops():
     syn = synaptic_operations()
     syn_ops = syn(model, out, inp)
 
-    assert syn_ops['MACs'] == 465
-    assert syn_ops['ACs'] == 0
+    assert syn_ops['Effective_MACs'] == 465
+    assert syn_ops['Effective_ACs'] == 0
 
     
     print('Passed synaptic ops')


### PR DESCRIPTION
This PR updates variable names in the syn_ops dictionary. It changes 'MACs' to 'Effective_MACs' and 'ACs' to 'Effective_ACs' for consistency in the codebase.