### PR TITLE
Fix typo in S2SPreProcessor

### DIFF
--- a/neurobench/examples/mswc_fscil/MSWC_tutorial.ipynb
+++ b/neurobench/examples/mswc_fscil/MSWC_tutorial.ipynb
@@ -44,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +261,7 @@
     "n_mfcc = 20\n",
     "\n",
     "if SPIKING:\n",
-    "    encode = S2SProcessor(device, transpose=True)\n",
+    "    encode = S2SPreProcessor(device, transpose=True)\n",
     "    config_change = {\"sample_rate\": 48000,\n",
     "                     \"hop_length\": 240}\n",
     "    encode.configure(threshold=1.0, **config_change)\n",


### PR DESCRIPTION
See title.

The original spelling was wrong, so the code would not work.