### PR TITLE
Fix list rendering in docs of MSWC dataset class

### DIFF
--- a/neurobench/datasets/MSWC_dataset.py
+++ b/neurobench/datasets/MSWC_dataset.py
@@ -257,6 +257,7 @@ class MSWC(Dataset):
     Subset version (https://huggingface.co/datasets/NeuroBench/mswc_fscil_subset)
     of the original MSWC dataset (https://mlcommons.org/en/multilingual-spoken-words/)
     for a few-shot class-incremental learning (FSCIL) task consisting of 200 voice commands keywords:
+
     - 100 base classes available for pre-training with:
         - 500 train samples
         - 100 validation samples


### PR DESCRIPTION
As rendered on site now:
<img width="677" alt="image" src="https://github.com/NeuroBench/neurobench/assets/24796206/ee986b97-362d-4ee3-bb7f-8a75b8386a4b">

Intended list:
<img width="636" alt="image" src="https://github.com/NeuroBench/neurobench/assets/24796206/405434c4-0bc2-4524-b9d2-44c8c208e1b5">
