### PR TITLE
Membrane Updates Metric

### DIFF
--- a/neurobench/benchmarks/benchmark.py
+++ b/neurobench/benchmarks/benchmark.py
@@ -5,7 +5,12 @@ from tqdm import tqdm
 from . import static_metrics, workload_metrics
 
 # workload metrics which require hooks
-requires_hooks = ["activation_sparsity", "number_neuron_updates", "synaptic_operations"]
+requires_hooks = [
+    "activation_sparsity",
+    "number_neuron_updates",
+    "synaptic_operations",
+    "membrane_updates",
+]
 
 
 class Benchmark:

--- a/neurobench/benchmarks/hooks.py
+++ b/neurobench/benchmarks/hooks.py
@@ -21,6 +21,8 @@ class ActivationHook:
         """
         self.activation_outputs = []
         self.activation_inputs = []
+        self.pre_fire_mem_potential = []
+        self.post_fire_mem_potential = []
         if layer is not None:
             self.hook = layer.register_forward_hook(self.hook_fn)
             self.hook_pre = layer.register_forward_pre_hook(self.pre_hook_fn)
@@ -46,6 +48,8 @@ class ActivationHook:
 
         """
         self.activation_inputs.append(input)
+        if self.spiking:
+            self.pre_fire_mem_potential.append(layer.mem)
 
     def hook_fn(self, layer, input, output):
         """
@@ -62,6 +66,7 @@ class ActivationHook:
         """
         if self.spiking:
             self.activation_outputs.append(output[0])
+            self.post_fire_mem_potential.append(layer.mem)
 
         else:
             self.activation_outputs.append(output)
@@ -75,6 +80,8 @@ class ActivationHook:
         """Resets the stored activation outputs and inputs."""
         self.activation_outputs = []
         self.activation_inputs = []
+        self.pre_fire_mem_potential = []
+        self.post_fire_mem_potential = []
 
     def close(self):
         """Remove the registered hook."""

--- a/neurobench/benchmarks/workload_metrics.py
+++ b/neurobench/benchmarks/workload_metrics.py
@@ -124,31 +124,32 @@ def activation_sparsity(model, preds, data):
 
 class membrane_updates(AccumulatedMetric):
     """
-    Number of synaptic operations.
+    Number of membrane potential updates.
 
-    MACs for ANN ACs for SNN
+    This metric can only be used for spiking models implemented with SNNTorch.
 
     """
 
     def __init__(self):
+        """Init metric state."""
         self.total_samples = 0
         self.neuron_membrane_updates = defaultdict(int)
 
     def reset(self):
+        """Reset metric state."""
         self.total_samples = 0
         self.neuron_membrane_updates = defaultdict(int)
 
     def __call__(self, model, preds, data):
         """
-        Multiply-accumulates (MACs) of the model forward.
+        Number of membrane updates of the model forward.
 
         Args:
             model: A NeuroBenchModel.
             preds: A tensor of model predictions.
             data: A tuple of data and labels.
-            inputs: A tensor of model inputs.
         Returns:
-            float: Multiply-accumulates.
+            float: Number of membrane potential updates.
 
         """
         for hook in model.activation_hooks:
@@ -164,6 +165,14 @@ class membrane_updates(AccumulatedMetric):
         return self.compute()
 
     def compute(self):
+        """
+        Compute membrane updates using accumulated data.
+
+        Returns:
+            float: Compute the total updates to each neuron's membrane potential within the model,
+            aggregated across all neurons and normalized by the number of samples processed.
+
+        """
         if self.total_samples == 0:
             return 0
 


### PR DESCRIPTION
# Description
This pull request introduces a new performance metric, membrane_updates. This metric counts the number of membrane potential updates within spiking neural networks (SNNs). It tracks these updates across different network neurons.

# Motivation
The membrane_updates metric aims to capture membrane potential development over multiple steps by counting stateful operations that, together with the synaptic operations, reflect the actual workload in neuromorphic computing models.

Recent research (https://arxiv.org/pdf/2306.15749v4.pdf) has highlighted the importance of considering stateful operations in the analysis of SNNs.