### PR TITLE
Fix AttributeError: 'Leaky' object has no attribute 'mem'

### DIFF
--- a/docs/metrics/workload_metrics/index.rst
+++ b/docs/metrics/workload_metrics/index.rst
@@ -8,6 +8,7 @@ Workload Metrics
    activation_sparsity
    synaptic_operations
    classification_accuracy
+   membrane_updates
    coco_map
    smape
    r2

--- a/docs/metrics/workload_metrics/membrane_updates.rst
+++ b/docs/metrics/workload_metrics/membrane_updates.rst
@@ -1,0 +1,37 @@
+===================
+Membrane Updates
+===================
+
+Definition
+----------
+
+During the execution of spiking neural networks (SNNs), the average number of updates to the neurons membrane potential is calculated over all neurons in the network, for all timesteps of all tested samples. This metric is specifically designed for spiking neural network implemented with SNNTorch.
+
+The number of membrane updates is calculated by accumulating the number of changes in membrane potential (i.e., the difference between pre- and post-spike membrane potentials) across all neuron layers, timesteps, and input samples, and then normalizing by the number of samples processed.
+
+Implementation Notes
+--------------------
+
+When the NeuroBench model is instatiated, certain layers can be recognized automatically for membrane updates calculation.
+
+.. Note::
+    The use of this metric are only available for neurons that, when initialized, have the ``init_hidden`` option set to ``True``.
+
+    Example:
+
+    .. code-block::
+
+        import snntorch as snn
+
+        # Initializing a Leaky neuron with init_hidden set to True
+        leaky_neuron = snn.Leaky(beta=0.5, output=True, init_hidden=True)
+
+
+
+These layers are:
+
+    - snn.SpikingNeuron layers (this is the parent class for all spiking neuron models)
+
+The membrane updates are calculated using hooks that save the pre- and post-spike membrane potentials of the neurons.
+At the end of the workload, the total number of membrane potential updates is summed over all layers and batches, and then divided by the number of samples to provide a normalized metric.
+

--- a/neurobench/benchmarks/hooks.py
+++ b/neurobench/benchmarks/hooks.py
@@ -48,7 +48,7 @@ class ActivationHook:
 
         """
         self.activation_inputs.append(input)
-        if self.spiking:
+        if self.spiking and hasattr(layer, "mem"):
             self.pre_fire_mem_potential.append(layer.mem)
 
     def hook_fn(self, layer, input, output):
@@ -66,7 +66,8 @@ class ActivationHook:
         """
         if self.spiking:
             self.activation_outputs.append(output[0])
-            self.post_fire_mem_potential.append(layer.mem)
+            if hasattr(layer, "mem"):
+                self.post_fire_mem_potential.append(layer.mem)
 
         else:
             self.activation_outputs.append(output)

--- a/neurobench/benchmarks/workload_metrics.py
+++ b/neurobench/benchmarks/workload_metrics.py
@@ -158,9 +158,10 @@ class membrane_updates(AccumulatedMetric):
                 post_fire_mem = hook.post_fire_mem_potential[index_mem + 1]
                 nr_updates = torch.count_nonzero(pre_fire_mem - post_fire_mem)
                 self.neuron_membrane_updates[str(type(hook.layer))] += int(nr_updates)
-            self.neuron_membrane_updates[str(type(hook.layer))] += int(
-                torch.numel(hook.post_fire_mem_potential[0])
-            )
+            if len(hook.post_fire_mem_potential) > 0:
+                self.neuron_membrane_updates[str(type(hook.layer))] += int(
+                    torch.numel(hook.post_fire_mem_potential[0])
+                )
         self.total_samples += data[0].size(0)
         return self.compute()
 


### PR DESCRIPTION
The current implementation of SNNTorch version 0.7.0 does not set the membrane potential (mem) as an attribute of the neuron classes (Leaky, Synaptic, etc...) unless the neuron is initialized with the option `init_hidden=True`. As a result, any hooks that attempt to register the pre- and post-membrane potentials will fail if this option is not enabled.

This pull request resolves this issue by ensuring that the `mem` attribute is properly set when the `init_hidden=True` option is used. Additionally, it updates the necessary documentation to guide users on correctly configuring their networks if they need to register membrane potential updates.