### PR TITLE
Bump version: 1.0.4 → 1.0.5

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -3,7 +3,7 @@
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 regex = false
-current_version = "1.0.4"
+current_version = "1.0.5"
 ignore_missing_version = false
 search = "{current_version}"
 replace = "{new_version}"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath(".."))
 project = "NeuroBench"
 copyright = "2024, Jason Yik, Noah Pacik-Nelson, Korneel Van Den Berghe"
 author = "Jason Yik, Noah Pacik-Nelson, Korneel Van Den Berghe"
-release = "1.0.4"
+release = "1.0.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "neurobench"
-version = "1.0.4"
+version = "1.0.5"
 description = "Collaborative, Fair, and Representative Benchmarks for Neuromorphic Computing"
 authors = ["NeuroBench Team <neurobench@googlegroups.com>"]
 readme = "README.rst"


### PR DESCRIPTION
Patch which adds checks to the snntorch hooks for `mem` attribute. Fixes the primate_reaching SNN examples from 1.0.4