### PR TITLE
Fix `export_to_nir` function missing from `snntorch`

### DIFF
--- a/neurobench/benchmarks/benchmark.py
+++ b/neurobench/benchmarks/benchmark.py
@@ -21,9 +21,6 @@ import pathlib
 import snntorch
 from torch import Tensor
 
-if snntorch.__version__ >= "0.9.0":
-    from snntorch import export_to_nir
-
 import torch
 import nir
 
@@ -222,6 +219,10 @@ class Benchmark:
         """
         if snntorch.__version__ < "0.9.0":
             raise ValueError("Exporting to NIR requires snntorch version >= 0.9.0")
+
+        if snntorch.__version__ >= "0.9.0":
+            from snntorch.export_nir import export_to_nir
+
         nir_graph = export_to_nir(self.model.__net__(), dummy_input, **kwargs)
         nir.write(filename, nir_graph)
         print(f"Model exported to {filename}")


### PR DESCRIPTION
Fixes #247.

Make `export_to_nir` import correct.

I also moved this import it into `.to_nir()` method, to make sure that people can also run benchmarks without having `nirtorch` installed. For example, for users like me who want to run the MSWC benchmark with an ANN, and do not use the functionality for exporting to NIR likely also do not have `nirtorch` installed.

For example, this is what currently happens if I run `from snntorch.export_nir import export_to_nir` in my terminal:

```bash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/space/ddenblanken/Projects/neurobench/neurobench/benchmarks/__init__.py", line 1, in <module>
    from .benchmark import Benchmark
  File "/space/ddenblanken/Projects/neurobench/neurobench/benchmarks/benchmark.py", line 25, in <module>
    from snntorch.export_nir import export_to_nir
  File "/users/ddenblanken/anaconda3/envs/meta_learning_arena/lib/python3.10/site-packages/snntorch/export_nir.py", line 8, in <module>
    import nirtorch
ModuleNotFoundError: No module named 'nirtorch'
```

To avoid that, I moved this import into the relevant export method, so that people who do not use this functionality are not forced to install `nirtorch`.

