### PR TITLE
Layer Wise Activation Sparsity

### DIFF
--- a/examples/nehar/benchmark.py
+++ b/examples/nehar/benchmark.py
@@ -9,7 +9,8 @@ from neurobench.metrics.workload import (
     ActivationSparsity,
     MembraneUpdates,
     SynapticOperations,
-    ClassificationAccuracy
+    ClassificationAccuracy,
+    ActivationSparsityByLayer,
 )
 from neurobench.metrics.static import (
     ParameterCount,
@@ -47,7 +48,7 @@ if __name__ == "__main__":
 
     # #
     static_metrics = [ParameterCount, Footprint, ConnectionSparsity]
-    workload_metrics = [ActivationSparsity, MembraneUpdates, SynapticOperations, ClassificationAccuracy]
+    workload_metrics = [ActivationSparsity, ActivationSparsityByLayer,MembraneUpdates, SynapticOperations, ClassificationAccuracy]
     # #
     benchmark = Benchmark(
         model, test_set_loader, [], postprocessors, [static_metrics, workload_metrics]

--- a/neurobench/hooks/neuron.py
+++ b/neurobench/hooks/neuron.py
@@ -10,7 +10,7 @@ class NeuronHook(ABC):
 
     """
 
-    def __init__(self, layer):
+    def __init__(self, layer, name=None):
         """
         Initializes the class.
 
@@ -24,6 +24,7 @@ class NeuronHook(ABC):
         self.activation_inputs = []
         self.pre_fire_mem_potential = []
         self.post_fire_mem_potential = []
+        self.name = name
         if layer is not None:
             self.hook = layer.register_forward_hook(self.hook_fn)
             self.hook_pre = layer.register_forward_pre_hook(self.pre_hook_fn)

--- a/neurobench/metrics/workload/__init__.py
+++ b/neurobench/metrics/workload/__init__.py
@@ -2,12 +2,19 @@ from .membrane_updates import MembraneUpdates
 from .activation_sparsity import ActivationSparsity
 from .synaptic_operations import SynapticOperations
 from .classification_accuracy import ClassificationAccuracy
+from .activation_sparsity_by_layer import ActivationSparsityByLayer
 from .mse import MSE
 from .smape import SMAPE
 from .r2 import R2
 from .coco_map import CocoMap
 
-__stateless__ = ["ClassificationAccuracy", "ActivationSparsity", "MSE", "SMAPE"]
+__stateless__ = [
+    "ClassificationAccuracy",
+    "ActivationSparsity",
+    "MSE",
+    "SMAPE",
+    "ActivationSparsityByLayer",
+]
 
 __stateful__ = ["MembraneUpdates", "SynapticOperations", "R2", "CocoMap"]
 

--- a/neurobench/metrics/workload/activation_sparsity_by_layer.py
+++ b/neurobench/metrics/workload/activation_sparsity_by_layer.py
@@ -5,7 +5,7 @@ import torch
 
 class ActivationSparsityByLayer(AccumulatedMetric):
     """
-    Sparsity layer by layer of model activations.
+    Sparsity layer-wise of model activations.
 
     Calculated as the number of zero activations over the number of activations layer by
     layer, over all timesteps, samples in data.

--- a/neurobench/metrics/workload/activation_sparsity_by_layer.py
+++ b/neurobench/metrics/workload/activation_sparsity_by_layer.py
@@ -4,18 +4,38 @@ import torch
 
 
 class ActivationSparsityByLayer(AccumulatedMetric):
+    """
+    Sparsity layer by layer of model activations.
+
+    Calculated as the number of zero activations over the number of activations layer by
+    layer, over all timesteps, samples in data.
+
+    """
 
     def __init__(self):
+        """Initialize the ActivationSparsityByLayer metric."""
         self.layer_sparsity = defaultdict(float)
         self.layer_neuro_num = defaultdict(int)
         self.layer_spike_num = defaultdict(int)
 
     def reset(self):
+        """Reset the metric."""
         self.layer_sparsity = defaultdict(float)
         self.layer_neuro_num = defaultdict(int)
         self.layer_spike_num = defaultdict(int)
 
     def __call__(self, model, preds, data):
+        """
+        Compute activation sparsity layer by layer.
+
+        Args:
+            model: A NeuroBenchModel.
+            preds: A tensor of model predictions.
+            data: A tuple of data and labels.
+        Returns:
+            float: Activation sparsity
+
+        """
 
         for hook in model.activation_hooks:
             name = hook.name
@@ -32,6 +52,7 @@ class ActivationSparsityByLayer(AccumulatedMetric):
         return self.compute()
 
     def compute(self):
+        """Compute the activation sparsity layer by layer."""
         for key in self.layer_neuro_num:
             sparsity = (
                 (self.layer_neuro_num[key] - self.layer_spike_num[key])

--- a/neurobench/metrics/workload/activation_sparsity_by_layer.py
+++ b/neurobench/metrics/workload/activation_sparsity_by_layer.py
@@ -1,0 +1,43 @@
+from neurobench.metrics.abstract.workload_metric import AccumulatedMetric
+from collections import defaultdict
+import torch
+
+
+class ActivationSparsityByLayer(AccumulatedMetric):
+
+    def __init__(self):
+        self.layer_sparsity = defaultdict(float)
+        self.layer_neuro_num = defaultdict(int)
+        self.layer_spike_num = defaultdict(int)
+
+    def reset(self):
+        self.layer_sparsity = defaultdict(float)
+        self.layer_neuro_num = defaultdict(int)
+        self.layer_spike_num = defaultdict(int)
+
+    def __call__(self, model, preds, data):
+
+        for hook in model.activation_hooks:
+            name = hook.name
+            if name is None:
+                continue
+            for output in hook.activation_outputs:
+                spike_num, neuro_num = torch.count_nonzero(
+                    output.dequantize() if output.is_quantized else output
+                ).item(), torch.numel(output)
+
+                self.layer_spike_num[name] += spike_num
+                self.layer_neuro_num[name] += neuro_num
+
+        return self.compute()
+
+    def compute(self):
+        for key in self.layer_neuro_num:
+            sparsity = (
+                (self.layer_neuro_num[key] - self.layer_spike_num[key])
+                / self.layer_neuro_num[key]
+                if self.layer_neuro_num[key] != 0
+                else 0.0
+            )
+            self.layer_sparsity[key] = sparsity
+        return dict(self.layer_sparsity)

--- a/neurobench/models/neurobench_model.py
+++ b/neurobench/models/neurobench_model.py
@@ -79,9 +79,9 @@ class NeuroBenchModel(ABC):
         def find_activation_layers(module):
             """Recursively find activation layers in a module."""
             layers = []
-            for child in module.children():
+            for child_name, child in module.named_children():
                 if is_activation_layer(child):
-                    layers.append(child)
+                    layers.append({"layer_name": child_name, "layer": child})
                 elif list(child.children()):  # Check for nested submodules
                     layers.extend(find_activation_layers(child))
             return layers
@@ -135,7 +135,9 @@ class NeuroBenchModel(ABC):
 
         # Registered activation hooks
         for layer in self.activation_layers():
-            self.activation_hooks.append(NeuronHook(layer))
+            layer_name = layer["layer_name"]
+            layer = layer["layer"]
+            self.activation_hooks.append(NeuronHook(layer, layer_name))
 
         for layer in self.connection_layers():
             self.connection_hooks.append(LayerHook(layer))

--- a/tests/models/model_list.py
+++ b/tests/models/model_list.py
@@ -1,9 +1,12 @@
 import torch.nn as nn
 import snntorch as snn
+from torch import manual_seed
 import snntorch.surrogate as surrogate
 
 beta = 0.9
+manual_seed(0)
 spike_grad = surrogate.fast_sigmoid()
+
 
 net = nn.Sequential(
     nn.Flatten(),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -8,6 +8,7 @@ from neurobench.metrics.workload import (
     ActivationSparsity,
     SynapticOperations,
     MembraneUpdates,
+    ActivationSparsityByLayer,
 )
 from neurobench.metrics.static import (
     Footprint,
@@ -104,6 +105,7 @@ class TestWorkloadMetrics(unittest.TestCase):
         self.activation_sparsity = ActivationSparsity()
         self.synaptic_operations = SynapticOperations()
         self.mem_updates = MembraneUpdates()
+        self.activation_sparsity_by_layer = ActivationSparsityByLayer()
 
     def test_classification_accuracy(self):
         model = SNNTorchModel(self.dummy_net)
@@ -428,6 +430,19 @@ class TestWorkloadMetrics(unittest.TestCase):
         tot_mem_updates = self.mem_updates(model, out, (inp, 0))
 
         self.assertEqual(tot_mem_updates, 50)
+
+    def test_activation_sparsity_by_layer(self):
+
+        inp = torch.ones(5, 10, 20)  # batch size, time steps, input size
+
+        model = SNNTorchModel(self.net_snn)
+
+        model.register_hooks()
+
+        out = model(inp)
+        act_sparsity_by_layer = self.activation_sparsity_by_layer(model, out, (inp, 0))
+
+        self.assertEqual(act_sparsity_by_layer["1"], 0.96)
 
 
 # TODO: refactor this metric if needed

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -428,6 +428,7 @@ class TestWorkloadMetrics(unittest.TestCase):
 
         out = model(inp)
         tot_mem_updates = self.mem_updates(model, out, (inp, 0))
+        self.mem_updates.reset()
 
         self.assertEqual(tot_mem_updates, 50)
 
@@ -441,6 +442,7 @@ class TestWorkloadMetrics(unittest.TestCase):
 
         out = model(inp)
         act_sparsity_by_layer = self.activation_sparsity_by_layer(model, out, (inp, 0))
+        self.activation_sparsity_by_layer.reset()
 
         self.assertEqual(act_sparsity_by_layer["1"], 0.96)
 


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and maintainability of the `neurobench` package. The most important change include adding a new metric for activation sparsity by layer, and enhancing the `NeuronHook` class to include layer names.

### New Metric Addition:
* Added a new metric `ActivationSparsityByLayer` in `neurobench/metrics/workload/activation_sparsity_by_layer.py` to calculate the sparsity of model activations on a per-layer basis.
* Updated the `__init__.py` file in `neurobench/metrics/workload` to include the new `ActivationSparsityByLayer` metric in the `__stateless__` list.

### Hook Enhancements:
* Enhanced the `NeuronHook` class in `neurobench/hooks/neuron.py` to include an optional `name` parameter, allowing hooks to store the name of the layer they are attached to. [[1]](diffhunk://#diff-57b3d3f8acc13ab61d60ff529051f74022880c5329b0ca23a12b2303a828143cL13-R13) [[2]](diffhunk://#diff-57b3d3f8acc13ab61d60ff529051f74022880c5329b0ca23a12b2303a828143cR27)
* Modified the `is_activation_layer` function and `register_hooks` method in `neurobench/models/neurobench_model.py` to include layer names when registering hooks. [[1]](diffhunk://#diff-e18efa1a82b655182b90dc783b52b1cc250b2ccf108d8a757b93bebbb5a21797L82-R84) [[2]](diffhunk://#diff-e18efa1a82b655182b90dc783b52b1cc250b2ccf108d8a757b93bebbb5a21797L138-R140)